### PR TITLE
update: node ci fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
         node-version: '14'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install


### PR DESCRIPTION
@MonalikaPatnaik This project not create with npm init so this is why `npm ci` not working and build is failing so we need `npm install` instead `npm ci`