### PR TITLE
Removed dark mode button from blogs page

### DIFF
--- a/src/Components/Blogs/index.js
+++ b/src/Components/Blogs/index.js
@@ -90,8 +90,6 @@ const Blogs = () => {
           </BlogsCard>
         ))}
       </BlogsWrapper>
-      <DarkMode >
-      </DarkMode>
     </BlogsContainer>
   );
 };


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Closes #596 

## Changes proposed

Hey @MonalikaPatnaik I have removed the extra dark mode button from the blogs page. Please review my pr and merge it. Thank you!

- Before
![Screenshot (831)](https://github.com/MonalikaPatnaik/UMatter/assets/100675296/014010fc-fd4e-4416-95a6-d18ec24981cd)

- After
![Screenshot (830)](https://github.com/MonalikaPatnaik/UMatter/assets/100675296/20b4f4e4-45d7-4af6-9d4d-6ee93ff84f01)

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.