### PR TITLE
Github icon hover changed

### DIFF
--- a/src/Components/Footer/FooterElements.js
+++ b/src/Components/Footer/FooterElements.js
@@ -148,6 +148,9 @@ export const FooterLink = styled(Link)`
   &.linkdn:hover{
     color:#0077B5 !important;
    }
+   &.github:hover{
+    color:black !important;
+   }
  `
  
  ;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue
Fixes #552
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
I have changed the styling on hovering above github icon.
Can it be merge now?
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.