### PR TITLE
Dark Mode Icon in Blog Page #602 Fixed

### DIFF
--- a/src/Components/Blogs/index.js
+++ b/src/Components/Blogs/index.js
@@ -1,11 +1,9 @@
 import React, { useState } from "react";
 import Icon1 from "../../images/no-drinking.png";
-import DarkMode from "../DarkMode/DarkMode";
 import Icon2 from "../../images/smoking-is-Injurious-to-Health.jpeg";
 import Icon3 from "../../images/Embracing_the_Power_of_Menstruation.png";
 import {
   BlogsContainer,
-  BlogsH1,
   BlogsH2,
   BlogsWrapper,
   BlogsCard,
@@ -90,8 +88,6 @@ const Blogs = () => {
           </BlogsCard>
         ))}
       </BlogsWrapper>
-      <DarkMode >
-      </DarkMode>
     </BlogsContainer>
   );
 };


### PR DESCRIPTION
This PR Fixed #602 issue,


## Changes proposed

I removed Extra Dark Mode Component From Blog Page

![Screenshot (290)](https://github.com/MonalikaPatnaik/UMatter/assets/99237795/4a491b90-9e9e-4414-809a-4e0cbaedab03)


<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.