### PR TITLE
Added label-issues workflow

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,35 @@
+name: Add Labels to Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Add 'gssoc23' Label to Issue
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const label = 'gssoc23';
+
+            const addLabelParams = {
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber,
+              labels: [label]
+            };
+
+            await github.issues.addLabels(addLabelParams);
+
+            console.log(`Added the 'gssoc23' label to Issue #${issueNumber}.`);


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

* Closes - #848 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

Added the automatic label issue workflow. Whenever a new issue will be created, a gssoc23 label will be added automatically by GitHub actions.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.