### PR TITLE
Display 'No results found' if the search result is null

### DIFF
--- a/src/Components/Blogs/index.js
+++ b/src/Components/Blogs/index.js
@@ -51,6 +51,31 @@ const Blogs = () => {
     blog.title.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
+  let content;
+  if (filteredBlogs.length === 0) {
+    content = <div>No results found</div>;
+  } else {
+    content = filteredBlogs.map((blog, index) => (
+      <BlogsCard key={index}>
+        <BlogsIcon src={blog.icon} />
+        <BlogsH1>
+          <b>{blog.title}</b>
+        </BlogsH1>
+        <BlogsP>{blog.content}</BlogsP>
+        {blog.hyperlink == "" ? (
+          <Link to="./abc">
+            <ReadMoreButton>Read more</ReadMoreButton>
+          </Link>
+        ) : (
+          <a href={blog.hyperlink} target="_blank">
+            <ReadMoreButton>Read more</ReadMoreButton>
+          </a>
+
+        )}
+      </BlogsCard>
+    ));
+  }
+
   return (
     <BlogsContainer id="Blogs">
       <div style={{ height: "100px" }}></div>
@@ -149,25 +174,7 @@ const Blogs = () => {
       <div style={{ height: "50px" }}></div>
       {/* <div style={{ height: "50px" }}></div> */}
       <BlogsWrapper>
-        {filteredBlogs.map((blog, index) => (
-          <BlogsCard key={index}>
-            <BlogsIcon src={blog.icon} />
-            <BlogsH1>
-              <b>{blog.title}</b>
-            </BlogsH1>
-            <BlogsP>{blog.content}</BlogsP>
-            {blog.hyperlink == "" ? (
-              <Link to="./abc">
-                <ReadMoreButton>Read more</ReadMoreButton>
-              </Link>
-            ) : (
-              <a href={blog.hyperlink} target="_blank">
-                <ReadMoreButton>Read more</ReadMoreButton>
-              </a>
-
-            )}
-          </BlogsCard>
-        ))}
+        {content}
       </BlogsWrapper>
     </BlogsContainer>
   );


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Closes #1044 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

I added a variable content which holds what the content of the search result should be displayed as. I set its value based on whether the result is null(if so a ```div``` containing "No results found" will be it's value) or not(the previous content to be shown is now the variable's value).

```js
 let content;
  if (filteredBlogs.length === 0) {
    content = <div>No results found</div>;
  } else {
    content = filteredBlogs.map((blog, index) => (
      <BlogsCard key={index}>
        <BlogsIcon src={blog.icon} />
        <BlogsH1>
          <b>{blog.title}</b>
        </BlogsH1>
        <BlogsP>{blog.content}</BlogsP>
        {blog.hyperlink == "" ? (
          <Link to="./abc">
            <ReadMoreButton>Read more</ReadMoreButton>
          </Link>
        ) : (
          <a href={blog.hyperlink} target="_blank">
            <ReadMoreButton>Read more</ReadMoreButton>
          </a>

        )}
      </BlogsCard>
    ));
```

Later on instead of the code that was there before, now I put the variable ```content``` between the BlogsWrapper tags.

```js
<BlogsWrapper>
        {content}
</BlogsWrapper>
```

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

#web_1402_issue